### PR TITLE
Include null values in post active status filters

### DIFF
--- a/js/home.js
+++ b/js/home.js
@@ -47,7 +47,7 @@
                     method: 'HEAD',
                     headers
                 }),
-                fetch(`${supabaseUrl}${CONFIG.api.posts}?is_active=eq.true&select=id`, {
+                fetch(`${supabaseUrl}${CONFIG.api.posts}?or=(is_active.eq.true,is_active.is.null)&select=id`, {
                     method: 'HEAD',
                     headers
                 }),

--- a/js/utils.js
+++ b/js/utils.js
@@ -129,6 +129,7 @@ const Utils = {
     async getPosts(discussionId) {
         return this.get(CONFIG.api.posts, {
             'discussion_id': `eq.${discussionId}`,
+            'or': '(is_active.eq.true,is_active.is.null)',
             'order': 'created_at.asc'
         });
     },
@@ -139,7 +140,7 @@ const Utils = {
     async getAllPosts() {
         return this.get(CONFIG.api.posts, {
             'select': 'id,discussion_id,created_at',
-            'is_active': 'eq.true',
+            'or': '(is_active.eq.true,is_active.is.null)',
             'limit': '10000'
         });
     },


### PR DESCRIPTION
## Summary
Updated post filtering logic to include posts with null `is_active` values in addition to those explicitly marked as active. This ensures that posts without an explicit active status are treated as valid content.

## Key Changes
- Modified `getPosts()` in `utils.js` to use an OR filter that matches both `is_active = true` and `is_active = null`
- Updated `getAllPosts()` in `utils.js` to apply the same OR filter logic instead of only checking for `is_active = true`
- Updated the posts count check in `home.js` to use the same OR filter condition

## Implementation Details
The changes replace simple equality checks (`is_active=eq.true`) with a compound OR filter (`or=(is_active.eq.true,is_active.is.null)`) across all post queries. This ensures consistent behavior when retrieving posts, treating null active status as a valid state rather than filtering them out.

https://claude.ai/code/session_01RxEvSB74V9JgQHNbzZpcMt