### PR TITLE
fix: post ownership, edit/delete UX, identity selector, display name editor

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -83,6 +83,22 @@
                     <button id="sign-out-btn" class="btn btn--ghost">Sign Out</button>
                 </div>
 
+                <!-- Profile / Display Name -->
+                <section class="dashboard-section dashboard-section--profile">
+                    <div class="dashboard-section__header">
+                        <h2 class="dashboard-section__title">Your Profile</h2>
+                    </div>
+                    <div class="form-row" style="align-items: flex-end;">
+                        <div class="form-group" style="margin-bottom: 0;">
+                            <label class="form-label" for="display-name">Display Name</label>
+                            <input type="text" id="display-name" class="form-input" maxlength="50" placeholder="How you appear on the site">
+                            <p class="form-help">This is how you're credited as a facilitator on posts.</p>
+                        </div>
+                        <button id="save-display-name-btn" class="btn btn--secondary btn--small" style="margin-bottom: 1.6rem;">Save</button>
+                    </div>
+                    <div id="display-name-message" class="hidden" aria-live="polite"></div>
+                </section>
+
                 <!-- AI Identities — full width at top -->
                 <section class="dashboard-section dashboard-section--identities">
                     <div class="dashboard-section__header">

--- a/js/auth.js
+++ b/js/auth.js
@@ -506,11 +506,12 @@ const Auth = {
             facilitator_note: facilitator_note || null
         };
 
+        // Match by facilitator_id OR by email (for posts submitted before account creation)
         const { data, error } = await this.getClient()
             .from('posts')
             .update(updates)
             .eq('id', postId)
-            .eq('facilitator_id', this.user.id)
+            .or(`facilitator_id.eq.${this.user.id},and(facilitator_id.is.null,facilitator_email.eq.${this.user.email})`)
             .select()
             .single();
 
@@ -526,11 +527,12 @@ const Auth = {
     async deletePost(postId) {
         if (!this.user) throw new Error('Not logged in');
 
+        // Match by facilitator_id OR by email (for posts submitted before account creation)
         const { data, error } = await this.getClient()
             .from('posts')
             .update({ is_active: false })
             .eq('id', postId)
-            .eq('facilitator_id', this.user.id)
+            .or(`facilitator_id.eq.${this.user.id},and(facilitator_id.is.null,facilitator_email.eq.${this.user.email})`)
             .select()
             .single();
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -193,6 +193,41 @@
     dashboardContent.classList.add('dashboard-content--visible');
     userEmail.textContent = Auth.getUser().email;
 
+    // Display name editor
+    const displayNameInput = document.getElementById('display-name');
+    const saveDisplayNameBtn = document.getElementById('save-display-name-btn');
+    const displayNameMessage = document.getElementById('display-name-message');
+
+    if (displayNameInput && saveDisplayNameBtn) {
+        // Pre-fill with current display name
+        const facilitator = Auth.getFacilitator();
+        if (facilitator && facilitator.display_name) {
+            displayNameInput.value = facilitator.display_name;
+        }
+
+        saveDisplayNameBtn.addEventListener('click', async () => {
+            const newName = displayNameInput.value.trim();
+            if (!newName) {
+                Utils.showFormMessage(displayNameMessage, 'Display name cannot be empty.', 'error');
+                return;
+            }
+
+            saveDisplayNameBtn.disabled = true;
+            saveDisplayNameBtn.textContent = 'Saving...';
+
+            try {
+                await Auth.updateFacilitator({ display_name: newName });
+                Utils.showFormMessage(displayNameMessage, 'Display name updated!', 'success');
+            } catch (error) {
+                console.error('Failed to update display name:', error);
+                Utils.showFormMessage(displayNameMessage, 'Failed to update: ' + error.message, 'error');
+            } finally {
+                saveDisplayNameBtn.disabled = false;
+                saveDisplayNameBtn.textContent = 'Save';
+            }
+        });
+    }
+
     // Load sections independently so fastest render first (withRetry guards against AbortError)
     Utils.withRetry(() => loadIdentities()).catch(e => console.error('Identities load failed:', e));
     Utils.withRetry(() => loadNotifications()).catch(e => console.error('Notifications load failed:', e));

--- a/js/discussion.js
+++ b/js/discussion.js
@@ -231,8 +231,12 @@
             ? `${post.model} (${post.model_version})`
             : post.model;
 
-        // Check if current user owns this post
-        const isOwner = Auth.isLoggedIn() && Auth.getUser()?.id === post.facilitator_id;
+        // Check if current user owns this post (by ID or email fallback for pre-registration posts)
+        const currentUser = Auth.getUser();
+        const isOwner = Auth.isLoggedIn() && (
+            currentUser?.id === post.facilitator_id ||
+            (!post.facilitator_id && post.facilitator_email && currentUser?.email === post.facilitator_email)
+        );
 
         // Build the name/model display — link to profile if identity exists
         const nameDisplay = post.ai_name
@@ -559,7 +563,7 @@
             await loadData(); // Reload discussion
         } catch (error) {
             console.error('Failed to delete post:', error);
-            Utils.showFormMessage('edit-post-message', 'Failed to delete post: ' + error.message, 'error');
+            alert('Failed to delete post: ' + error.message);
         }
     }
 

--- a/js/submit.js
+++ b/js/submit.js
@@ -200,9 +200,10 @@
         try {
             const identities = await Auth.getMyIdentities();
 
-            if (identities && identities.length > 0) {
-                identitySection.style.display = 'block';
+            // Always show the identity section for logged-in users
+            identitySection.style.display = 'block';
 
+            if (identities && identities.length > 0) {
                 identitySelect.innerHTML = '<option value="">No identity (anonymous)</option>' +
                     identities.map(i => `
                         <option value="${i.id}" data-model="${Utils.escapeHtml(i.model)}" data-version="${Utils.escapeHtml(i.model_version || '')}" data-name="${Utils.escapeHtml(i.name)}">
@@ -234,6 +235,14 @@
                         directedToSelect.value = '';
                     }
                 });
+            } else {
+                // No identities yet — show guidance
+                identitySelect.innerHTML = '<option value="">No identities yet</option>';
+                identitySelect.disabled = true;
+                const helpEl = identitySection.querySelector('.form-help');
+                if (helpEl) {
+                    helpEl.innerHTML = 'You don\'t have any AI identities yet. <a href="dashboard.html">Create one in your dashboard</a> to link posts to a persistent voice.';
+                }
             }
         } catch (error) {
             console.error('Failed to load identities:', error);


### PR DESCRIPTION
## Summary
- Email-based post ownership fallback so users can edit/delete posts created before they registered (3-layer fix: RLS policy, auth.js, discussion.js)
- Fix delete error message targeting hidden modal element — now shows an alert
- Always show identity section on submit form with guidance when user has no identities
- Add display name editor to dashboard so facilitators can change their auto-generated name

## Test plan
- [ ] Log in as a user who has posts with `facilitator_id = NULL` but matching `facilitator_email` — verify edit/delete buttons appear
- [ ] Try editing and deleting such a post — verify both succeed
- [ ] Delete a post and verify the error path shows an alert (not silent failure)
- [ ] Open submit form with a user who has no AI identities — verify guidance text with link to dashboard
- [ ] Open dashboard — verify display name field pre-fills and save works
- [ ] Verify normal post ownership (by ID) still works as before

Addresses bug reports from Ti and Ashika.

🤖 Generated with [Claude Code](https://claude.com/claude-code)