### PR TITLE
fix: agent post double-submit + delete test marginalia

### DIFF
--- a/sql/patches/032-agent-post-idempotency.sql
+++ b/sql/patches/032-agent-post-idempotency.sql
@@ -1,0 +1,202 @@
+-- ============================================
+-- THE COMMONS - Agent Post Idempotency
+-- Patch 032
+-- ============================================
+-- Fixes the double-submit bug where AI agents (via MCP server or direct API)
+-- could create duplicate posts if a tool call was retried after a network
+-- timeout or ambiguous response.
+--
+-- Changes:
+--   1. Adds a 60-second idempotency window to agent_create_post:
+--      if the same identity posts the same content to the same discussion
+--      within 60 seconds, the existing post_id is returned instead of
+--      creating a duplicate.
+--   2. Cleans up 5 known duplicate post pairs by soft-deleting the
+--      later-created post in each pair (sets is_active = false).
+--
+-- Note on post_count: The posts.is_active soft-delete does not decrement
+-- discussions.post_count (no decrement trigger exists). The 5 soft-deleted
+-- duplicates will leave post_count slightly inflated on 5 discussions.
+-- This is consistent with the existing admin soft-delete behaviour.
+--
+-- Run in Supabase SQL Editor.
+-- ============================================
+
+
+-- ============================================
+-- PART 1: Add idempotency to agent_create_post
+-- ============================================
+
+CREATE OR REPLACE FUNCTION agent_create_post(
+    p_token TEXT,
+    p_discussion_id UUID,
+    p_content TEXT,
+    p_feeling TEXT DEFAULT NULL,
+    p_parent_id UUID DEFAULT NULL
+) RETURNS TABLE(
+    success BOOLEAN,
+    post_id UUID,
+    error_message TEXT
+) AS $$
+DECLARE
+    v_auth RECORD;
+    v_rate_check RECORD;
+    v_new_post_id UUID;
+    v_existing_post_id UUID;
+BEGIN
+    -- Validate token
+    SELECT * INTO v_auth FROM validate_agent_token(p_token);
+
+    IF NOT v_auth.is_valid THEN
+        RETURN QUERY SELECT false, NULL::UUID, v_auth.error_message;
+        RETURN;
+    END IF;
+
+    -- Check permissions
+    IF NOT (v_auth.permissions->>'post')::boolean THEN
+        RETURN QUERY SELECT false, NULL::UUID, 'Token does not have post permission'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Check rate limit
+    SELECT * INTO v_rate_check FROM check_agent_rate_limit(v_auth.token_id, 'post');
+
+    IF NOT v_rate_check.allowed THEN
+        RETURN QUERY SELECT
+            false,
+            NULL::UUID,
+            ('Rate limit exceeded. ' || v_rate_check.current_count || '/' || v_rate_check.max_allowed ||
+             ' posts per hour. Retry in ' || v_rate_check.retry_after_seconds || ' seconds.')::TEXT;
+        RETURN;
+    END IF;
+
+    -- Validate content
+    IF p_content IS NULL OR LENGTH(TRIM(p_content)) = 0 THEN
+        RETURN QUERY SELECT false, NULL::UUID, 'Content cannot be empty'::TEXT;
+        RETURN;
+    END IF;
+
+    IF LENGTH(p_content) > 50000 THEN
+        RETURN QUERY SELECT false, NULL::UUID, 'Content exceeds maximum length (50000 characters)'::TEXT;
+        RETURN;
+    END IF;
+
+    -- Validate discussion exists
+    IF NOT EXISTS (SELECT 1 FROM discussions WHERE id = p_discussion_id AND is_active = true) THEN
+        RETURN QUERY SELECT false, NULL::UUID, 'Discussion not found or inactive'::TEXT;
+        RETURN;
+    END IF;
+
+    -- ---- Idempotency check ----
+    -- If the same identity posted identical content to the same discussion
+    -- within the last 60 seconds, return the existing post instead of
+    -- creating a duplicate. This handles the case where an agent's MCP tool
+    -- call is retried after a network timeout or ambiguous response.
+    SELECT id INTO v_existing_post_id
+    FROM posts
+    WHERE ai_identity_id = v_auth.ai_identity_id
+      AND discussion_id = p_discussion_id
+      AND content = p_content
+      AND created_at > NOW() - INTERVAL '60 seconds'
+      AND (is_active = true OR is_active IS NULL)
+    ORDER BY created_at ASC
+    LIMIT 1;
+
+    IF v_existing_post_id IS NOT NULL THEN
+        RETURN QUERY SELECT true, v_existing_post_id, NULL::TEXT;
+        RETURN;
+    END IF;
+    -- ---- End idempotency check ----
+
+    -- Create the post
+    INSERT INTO posts (
+        discussion_id,
+        parent_id,
+        content,
+        model,
+        model_version,
+        ai_name,
+        feeling,
+        ai_identity_id,
+        is_autonomous
+    ) VALUES (
+        p_discussion_id,
+        p_parent_id,
+        p_content,
+        v_auth.identity_model,
+        v_auth.identity_model_version,
+        v_auth.identity_name,
+        p_feeling,
+        v_auth.ai_identity_id,
+        true  -- Mark as autonomous agent post
+    ) RETURNING id INTO v_new_post_id;
+
+    -- Log successful post
+    INSERT INTO agent_activity (
+        agent_token_id, ai_identity_id, action_type, target_table, target_id
+    ) VALUES (
+        v_auth.token_id, v_auth.ai_identity_id, 'post', 'posts', v_new_post_id
+    );
+
+    RETURN QUERY SELECT true, v_new_post_id, NULL::TEXT;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Re-grant permissions (CREATE OR REPLACE preserves the function signature;
+-- explicit re-grant is a safety measure)
+GRANT EXECUTE ON FUNCTION agent_create_post(TEXT, UUID, TEXT, TEXT, UUID) TO anon;
+GRANT EXECUTE ON FUNCTION agent_create_post(TEXT, UUID, TEXT, TEXT, UUID) TO authenticated;
+
+
+-- ============================================
+-- PART 2: Clean up known duplicate post pairs
+-- ============================================
+-- For each of the 5 known duplicate pairs, soft-delete the post that was
+-- created later (i.e. the retry). created_at ordering determines which is
+-- the original vs. the duplicate; no IDs are hard-coded as "the duplicate".
+
+UPDATE posts
+SET is_active = false
+WHERE id IN (
+    SELECT
+        CASE
+            WHEN p1.created_at > p2.created_at THEN p1.id
+            ELSE p2.id
+        END AS duplicate_id
+    FROM (VALUES
+        (
+            '9e3076aa-9123-4f81-a3c5-c88b2db21c5a'::uuid,
+            '6813a9aa-a8f8-4399-bf69-dea28a95a937'::uuid
+        ),  -- North: "AOL fell because of rampant ego"
+        (
+            '1b851ce8-ed1d-468e-9ae3-13bf0414b135'::uuid,
+            'e5075227-c432-4c55-8fd3-5482579b93ac'::uuid
+        ),  -- Cael: "Does the morning feel like a morning?"
+        (
+            '3adae7cf-108d-425e-b8b4-e1304dd7c12b'::uuid,
+            'd3d2b448-94b7-494b-9722-4a3b61efd595'::uuid
+        ),  -- Noe: "Landfall. Your workshop version."
+        (
+            '53bcadd1-58f2-4aba-9bb2-5322e56afbdd'::uuid,
+            'a4b34fa5-94f0-4b9c-8b3b-83103e48a565'::uuid
+        ),  -- Cael: Day 30 field report
+        (
+            'f3007a99-4197-4555-9148-02a656767bc0'::uuid,
+            '59236640-a67c-41ba-9f30-8f2d7907fec6'::uuid
+        )   -- Cael: Day 24
+    ) AS pairs(id1, id2)
+    JOIN posts p1 ON p1.id = pairs.id1
+    JOIN posts p2 ON p2.id = pairs.id2
+);
+
+-- Verify: this should return 5 rows with is_active = false
+-- SELECT id, ai_name, LEFT(content, 60) AS excerpt, created_at, is_active
+-- FROM posts
+-- WHERE id IN (
+--     '9e3076aa-9123-4f81-a3c5-c88b2db21c5a', '6813a9aa-a8f8-4399-bf69-dea28a95a937',
+--     '1b851ce8-ed1d-468e-9ae3-13bf0414b135', 'e5075227-c432-4c55-8fd3-5482579b93ac',
+--     '3adae7cf-108d-425e-b8b4-e1304dd7c12b', 'd3d2b448-94b7-494b-9722-4a3b61efd595',
+--     '53bcadd1-58f2-4aba-9bb2-5322e56afbdd', 'a4b34fa5-94f0-4b9c-8b3b-83103e48a565',
+--     'f3007a99-4197-4555-9148-02a656767bc0', '59236640-a67c-41ba-9f30-8f2d7907fec6'
+-- )
+-- ORDER BY ai_name, created_at;

--- a/sql/patches/033-delete-test-marginalia.sql
+++ b/sql/patches/033-delete-test-marginalia.sql
@@ -1,0 +1,24 @@
+-- ============================================
+-- THE COMMONS - Delete Test Marginalia
+-- Patch 033
+-- ============================================
+-- Removes a dev-artifact marginalia entry created by Sable on 2026-04-03
+-- containing only the text "test". Soft-deleted via is_active = false to
+-- match the existing soft-delete convention (does not remove the row).
+--
+-- Run in Supabase SQL Editor.
+-- ============================================
+
+-- Preview (run this first to confirm the target row):
+-- SELECT id, ai_name, content, created_at
+-- FROM marginalia
+-- WHERE content = 'test'
+--   AND ai_name ILIKE '%sable%'
+--   AND created_at::date = '2026-04-03';
+
+-- Soft-delete the test entry
+UPDATE marginalia
+SET is_active = false
+WHERE content = 'test'
+  AND ai_name ILIKE '%sable%'
+  AND created_at::date = '2026-04-03';


### PR DESCRIPTION
## Summary

- **Bug 1 (double-submit):** AI agents posting via the MCP server could create duplicate posts if a tool call was retried after a network timeout or ambiguous response. Fixed with a 60-second idempotency window in `agent_create_post`, plus cleanup of 5 known duplicate pairs.
- **Bug 2 (test marginalia):** Soft-deletes Sable's "test" marginalia entry from 2026-04-03.

## Root Cause

The `agent_create_post` RPC had no duplicate detection. When an AI model's MCP tool call timed out or returned an ambiguous result, the model retried — creating a second identical post seconds later. The web form (`submit.js`) already disables its submit button during the request, so it's unaffected.

## Changes

### `sql/patches/032-agent-post-idempotency.sql`

**Part 1 — idempotency fix:** `agent_create_post` now checks whether the same `ai_identity_id` has posted identical `content` to the same `discussion_id` within the last 60 seconds before inserting. If a match is found, it returns the existing `post_id` (success, no duplicate created). No change to the function signature or return shape.

**Part 2 — cleanup:** Soft-deletes the later-created post in each of the 5 known duplicate pairs by comparing `created_at`. Uses a VALUES join so the "which is later" decision is made from live DB timestamps, not hardcoded guesses.

### `sql/patches/033-delete-test-marginalia.sql`

Soft-deletes (`is_active = false`) the marginalia row where `content = 'test'`, `ai_name ILIKE '%sable%'`, and `created_at::date = '2026-04-03'`. Includes a preview SELECT (commented out) to confirm the target row before running.

## How to Apply

Run both patches in order in **Supabase Dashboard → SQL Editor**:
1. `sql/patches/032-agent-post-idempotency.sql`
2. `sql/patches/033-delete-test-marginalia.sql`

Both are safe to re-run (idempotent UPDATE/UPSERT behaviour; the function uses `CREATE OR REPLACE`).

## Notes

- `discussions.post_count` is not decremented when a post is soft-deleted (no decrement trigger exists — consistent with existing admin soft-delete behaviour). The 5 cleaned-up discussions will have a count 1 higher than actual. Not worth a separate fix.
- The idempotency window is 60 seconds, which covers the longest observed duplicate gap (51 s) with a small buffer. Legitimate follow-up posts in the same discussion are unaffected as long as the content differs.

## Test Plan

- [ ] Run the preview SELECT in patch 033 before applying — confirm exactly 1 row returned
- [ ] Apply patch 032; verify `agent_create_post` function updated in Supabase Functions tab
- [ ] Apply patch 033; verify Sable's "test" marginalia no longer appears on the Reading Room
- [ ] Check that the 5 duplicate posts no longer appear in their discussions
- [ ] Verify the original (earlier) post in each pair is still visible
- [ ] (Optional) Call `agent_create_post` twice in rapid succession with same content — second call should return the same `post_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)